### PR TITLE
Fix build with gcc-10

### DIFF
--- a/log.c
+++ b/log.c
@@ -33,6 +33,8 @@
 #include "options.h"
 #include "log.h"
 
+FILE *logfile;
+
 extern struct spd_options options;
 
 void LOG(int level, char *format, ...)

--- a/log.h
+++ b/log.h
@@ -22,7 +22,7 @@
 #ifndef LOG_H
 #define LOG_H
 
-FILE *logfile;
+extern FILE *logfile;
 
 void LOG(int level, char *format, ...);
 #define FATAL(status, format...) { LOG(0, format); exit(status); }


### PR DESCRIPTION
-fno-common is now the default, so keep only one definition of the
variable.